### PR TITLE
ledger: allow for overriding net/http.Client used, read LEDGER_* env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 Go SDK for [QLedger](https://github.com/RealImage/QLedger)
 
 Refer [![GoDoc](https://godoc.org/github.com/RealImage/qledger-sdk-go?status.svg)](https://godoc.org/github.com/RealImage/qledger-sdk-go) for documentation.
+
+### Configuration
+
+The following environmental variables can be set to configure a `Ledger` instance:
+
+- `LEDGER_AUTH_TOKEN`: Token used to authenticate with a QLedger instance. (Example: `long-complex-secret-token`)
+- `LEDGER_ENDPOINT`: HTTP address for QLedger instance (Example: `http://127.0.0.1:7000/qledger/`)

--- a/ledger.go
+++ b/ledger.go
@@ -3,17 +3,28 @@ package ledger
 import (
 	"io"
 	"net/http"
+	"os"
 )
 
 // Ledger is the interface to all ledger API calls
 type Ledger struct {
+	HTTP *http.Client
+
 	endpoint  string
 	authToken string
 }
 
 // NewLedger returns instance of a Ledger
-func NewLedger(endpoint string, authToken string) Ledger {
-	return Ledger{endpoint: endpoint, authToken: authToken}
+//
+// api := ledger.NewLedger("https://example.com/qledger", "secret-auth-token")
+func NewLedger(endpoint string, authToken string) *Ledger {
+	if endpoint == "" {
+		endpoint = os.Getenv("LEDGER_ENDPOINT")
+	}
+	if authToken == "" {
+		authToken = os.Getenv("LEDGER_AUTH_TOKEN")
+	}
+	return &Ledger{endpoint: endpoint, authToken: authToken}
 }
 
 // GetEndpoint returns the enpoint of the ledger
@@ -23,7 +34,10 @@ func (l *Ledger) GetEndpoint() string {
 
 // DoRequest creates a new request to Ledger with necessary headers set
 func (l *Ledger) DoRequest(method, url string, body io.Reader) (*http.Response, error) {
-	client := &http.Client{}
+	client := l.HTTP
+	if client == nil {
+		client = &http.Client{}
+	}
 	req, _ := http.NewRequest(method, l.endpoint+url, body)
 	req.Header.Set("Content-Type", "application/json")
 	if l.authToken != "" {


### PR DESCRIPTION
This allows callers to specify timeouts on the HTTP client used.