### PR TITLE
ledger: wrap response errors with HTTP metadata

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -1,6 +1,7 @@
 package ledger
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 )
@@ -29,5 +30,9 @@ func (l *Ledger) DoRequest(method, url string, body io.Reader) (*http.Response, 
 	if l.authToken != "" {
 		req.Header.Add("Authorization", l.authToken)
 	}
-	return client.Do(req)
+	resp, err := client.Do(req)
+	if err != nil || (resp != nil && resp.StatusCode > 399) {
+		return resp, fmt.Errorf("qledger: %s %s received HTTP status %s", req.Method, req.URL.String(), resp.Status)
+	}
+	return resp, err
 }


### PR DESCRIPTION
I found enhancing the error helps to debug problems. I don't consider the URL (i.e. account ID) sensitive since it would end up in load balancer logs. 